### PR TITLE
Add DevIntro CLI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/README.md
+++ b/README.md
@@ -1,1 +1,25 @@
-# CLIck-Me2
+# DevIntro CLI
+
+A simple command-line interface for showing developer introductions.
+
+## Installation
+
+Install the package with `pip`:
+
+```bash
+pip install -e .
+```
+
+## Usage
+
+Run the CLI with default profile:
+
+```bash
+devintro info
+```
+
+You can specify a custom profile file:
+
+```bash
+devintro --config path/to/profile.yaml skills
+```

--- a/devintro/__init__.py
+++ b/devintro/__init__.py
@@ -1,0 +1,5 @@
+"""Developer introduction CLI package."""
+
+__all__ = ["cli"]
+
+from .cli import cli

--- a/devintro/cli.py
+++ b/devintro/cli.py
@@ -1,0 +1,39 @@
+import click
+from .profile import load_profile, Profile
+
+
+@click.group()
+@click.option('--config', type=click.Path(exists=True), help='Path to profile config file')
+@click.pass_context
+def cli(ctx: click.Context, config: str | None):
+    """Developer introduction command line interface."""
+    ctx.obj = load_profile(config)
+
+
+@cli.command()
+@click.pass_obj
+def info(profile: Profile):
+    """Show basic information."""
+    click.echo(profile.bio)
+
+
+@cli.command()
+@click.pass_obj
+def skills(profile: Profile):
+    """List skills."""
+    click.echo("\n".join(profile.skills))
+
+
+@cli.command()
+@click.pass_obj
+def projects(profile: Profile):
+    """List projects."""
+    click.echo("\n".join(profile.projects))
+
+
+@cli.command()
+@click.pass_obj
+def contacts(profile: Profile):
+    """Show contact information."""
+    for key, value in profile.contacts.items():
+        click.echo(f"{key}: {value}")

--- a/devintro/data/default_profile.json
+++ b/devintro/data/default_profile.json
@@ -1,0 +1,10 @@
+{
+  "name": "Jane Developer",
+  "bio": "Jane is a passionate software developer who loves Python.",
+  "skills": ["Python", "Django", "Flask"],
+  "projects": ["DevIntro CLI", "Awesome Web App"],
+  "contacts": {
+    "Email": "jane@example.com",
+    "GitHub": "https://github.com/jane"
+  }
+}

--- a/devintro/profile.py
+++ b/devintro/profile.py
@@ -1,0 +1,49 @@
+from dataclasses import dataclass
+from pathlib import Path
+from typing import List, Dict, Optional
+import json
+
+try:
+    import yaml
+except ImportError:  # pragma: no cover - yaml is optional
+    yaml = None
+
+
+@dataclass
+class Profile:
+    name: str
+    bio: str
+    skills: List[str]
+    projects: List[str]
+    contacts: Dict[str, str]
+
+
+def load_profile(path: Optional[str] = None) -> Profile:
+    """Load profile data from JSON or YAML file.
+
+    If no path is provided, load the default profile bundled with the
+    package.
+    """
+    if path is None:
+        default_path = Path(__file__).parent / "data" / "default_profile.json"
+        path = str(default_path)
+    file_path = Path(path)
+    if not file_path.exists():
+        raise FileNotFoundError(f"Profile file not found: {path}")
+    text = file_path.read_text(encoding="utf-8")
+    if file_path.suffix.lower() in {".yaml", ".yml"}:
+        if yaml is None:
+            raise RuntimeError("PyYAML is required to load YAML files")
+        data = yaml.safe_load(text)
+    elif file_path.suffix.lower() == ".json":
+        data = json.loads(text)
+    else:
+        raise ValueError("Unsupported file type")
+
+    return Profile(
+        name=data.get("name", ""),
+        bio=data.get("bio", ""),
+        skills=data.get("skills", []),
+        projects=data.get("projects", []),
+        contacts=data.get("contacts", {}),
+    )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,18 @@
+[build-system]
+requires = ["setuptools>=61"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "devintro"
+version = "0.1.0"
+description = "Developer introduction CLI"
+authors = [{name = "Example", email = "example@example.com"}]
+readme = "README.md"
+requires-python = ">=3.8"
+dependencies = [
+    "click",
+    "pyyaml",
+]
+
+[project.scripts]
+devintro = "devintro.cli:cli"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,23 @@
+from click.testing import CliRunner
+from devintro.cli import cli
+from devintro.profile import load_profile
+
+
+def test_load_profile_default():
+    profile = load_profile()
+    assert profile.name == "Jane Developer"
+    assert "Python" in profile.skills
+
+
+def test_cli_info():
+    runner = CliRunner()
+    result = runner.invoke(cli, ["info"])
+    assert result.exit_code == 0
+    assert "Jane" in result.output
+
+
+def test_cli_skills():
+    runner = CliRunner()
+    result = runner.invoke(cli, ["skills"])
+    assert result.exit_code == 0
+    assert "Python" in result.output


### PR DESCRIPTION
## Summary
- implement a simple developer intro CLI using click
- load profile data from JSON
- provide commands for info, skills, projects and contacts
- add example profile and tests
- document usage in README

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6863ef416de883279c27735c349e1a2f